### PR TITLE
Support some more attachment-related edge cases

### DIFF
--- a/src/GmailAPI.ts
+++ b/src/GmailAPI.ts
@@ -155,6 +155,12 @@ async function getAttachments(gmail:gmail_v1.Gmail, account:string, msgId: strin
         const part = parts[i];
         const filename = part.filename
         const attach_id = part.body.attachmentId
+
+		if(!filename || !attach_id) {
+			console.debug(msgId, `Part ${i} has no filename or attachmentId, skipping...`)
+			continue
+		}
+
         const ares = await getAttachment(gmail, account, msgId, attach_id)
         const red = ares.data?.data?.replace(/-/g, '+').replace(/_/g, '/') || ""
         const init_name = filename

--- a/src/GmailAPI.ts
+++ b/src/GmailAPI.ts
@@ -176,7 +176,7 @@ function flatten_parts(dst:any, parts:any){
     }
     else {
         for(let i = 0; i < parts.length;i++){
-            if(parts[i].mimeType=='multipart/related'||parts[i].mimeType=="multipart/alternative")
+            if(parts[i].mimeType=='multipart/related'||parts[i].mimeType=="multipart/alternative" || parts[i].mimeType=="multipart/mixed")
                 flatten_parts(dst, parts[i].parts)
             else
                 dst.assets.push(parts[i])


### PR DESCRIPTION
Some emails were refusing to fetch for me, resulting in the same error as #30 .

Debugging this, I discovered the affected messages had a MIME type of `multipart/mixed`, which was not being picked up by `flatten_parts`. This in turn resulted in an empty body, which crashed the plugin.

I also noticed that the plugin sometimes misinterpreted empty parts as attachments.

This PR addresses both.